### PR TITLE
Adding Orchard CMS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
 - [Laravel Scout](https://laravel.com/docs/master/scout)
 - [Shopware](https://github.com/synonymous1984/SwAlgolia)
 - [eXist-db](https://github.com/BCDH/exist-algolia-index)
+- [Orchard CMS](https://github.com/Lombiq/Orchard-Algolia-Search)
 
 ## Libraries & Tools
 


### PR DESCRIPTION
Also wanted to add the https://algoliasearchdemo.dotnest.com/ demo site and that the module is also available on https://dotnest.com/, but not sure where to put these, and maybe all of this would be too much. Please advise.