### PR TITLE
Add Terraform Algolia Provider to comunity libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@
   - [mongoose-algolia](https://github.com/crsten/mongoose-algolia)
   - [mongoolia-v5](https://github.com/thedv91/mongoolia-v5)
   - [mongoolia](https://github.com/algolia/mongoolia)
+- [Terraform Provider](https://registry.terraform.io/providers/k-yomo/algolia/latest/docs)
 
 ## Demos
 


### PR DESCRIPTION
I'm maintaining [Terraform Algolia Provider](https://github.com/k-yomo/terraform-provider-algolia) and it would be great if we can list it for those who wants to manage Algolia configuration as code!